### PR TITLE
Add use of names and remove initial participation limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # _n_-item Raffle Simulation using "Algorithm R" aka. "Crazy Bus Driver Algorithm"
 
 This script is useful for running an raffle where you are giving away _n_
-identical items to _p_ participants where _n < p_. Each participant will have a
+identical items to an unknown number _p_ participants where _n <= p_. Each participant will have a
 equal probability of having one of the items by the end of the simulation.
 
 Mathematically, this relies on "Algorithm R" for reservoir sampling:
@@ -26,16 +26,19 @@ Here is a sample run of the script:
 
     What are you giving away? shirts
     How many shirts are you giving away? 10
-    How many people are participating? 35
+    Do you want to enter names? (y/N) n
     To start, participants 0 through 9 get one of the shirts (for now...)
 
     List anyone who was gone, end with a blank line...
     4
     Participant 10 gets one of the shirts (for now) then.
 
-    Is participant 11 here (y/n)? y
+    Continue with participant 11 (Y/n)? y
     Nothing happened.
-    Is participant 12 here (y/n)? y
+    Continue with participant 12 (Y/n)? y
     Participant 12 steals one of the shirts from participant 6!
     ...
-
+    Continue with particpant 54 (Y/n)? n
+    Quit entirely (y/N)? y
+    
+    Winners are: 0, 14, 3, 48, 22, 35, 50, and 25!

--- a/busraffle.py
+++ b/busraffle.py
@@ -4,31 +4,84 @@ rng = SystemRandom()
 
 item = input("What are you giving away? ")
 n = int(input("How many {} are you giving away? ".format(item)))
-participants = int(input("How many people are participating? "))
-
-print("To start, participants 0 through {} get one of the {} (for now...)".format(n - 1, item))
-bus = list(range(n))
+temp = input("Do you want to enter names? (y/N) ")
 print()
+useNames = (temp == "yes" or temp == "y" or temp == "Yes" or temp == "Y")
+
+names = {}
+
+if useNames:
+    for i in range(n):
+        names[i] = input("Participant: ")
+        print("You get one of the {}! For now.".format(item))
+    print()
+else:
+    print("To start, participants 0 through {} get one of the {} (for now...)".format(n - 1, item))
+    for i in range(n):
+        names[i] = str(i)
+    print()
+
+bus =  list(range(n))
+
 print("List anyone who was gone, end with a blank line...")
 s = n
 while True:
     line = input()
     if line == '':
         break
-    print("Participant {} gets one of the {} (for now) then.".format(s, item))
-    bus[bus.index(int(line))] = s
-    s += 1
-
-j = n
-for e in range(s, participants):
-    here = input("Is participant {} here (y/n)? ".format(e)) == 'y'
-    if not here:
+    index = -1
+    for i, name in names.items():
+        if line == name:
+            index = i
+            break
+    if index == -1:
         continue
-    j = j + 1
-    if rng.random() < n / j:
+
+    if useNames:
+        names[index] = input("New Participant: ")
+    else:
+        names[index] = str(s)
+    s += 1
+    print("New Participant {} gets one of the {} (for now) then.".format(names[index], item))
+
+e = s
+j = n
+while True:
+    if useNames:
+        temp = input("Continue with participant (Y/n)? ")
+        quit = temp == 'y' or temp == 'Y' or temp == "yes" or temp == "Yes" or temp == ''
+        if not quit:
+            break
+    else:
+        temp = input("Continue with participant {} (Y/n)? ".format(e))
+        here = temp == 'y' or temp == 'Y' or temp == "yes" or temp == "Yes" or temp == ''
+        if not here:
+            temp = input("Quit entirely (y/N)? ")
+            if temp == 'y' or temp == 'Y' or temp == "yes" or temp == "Yes":
+                break
+            e += 1
+            continue
+
+    e = e + 1
+    if useNames:
+        temp = input("Participant: ")
+        names[j] = temp
+    else:
+        names[j] = e
+
+    if rng.random() < (n / len(names)):
         i = rng.randrange(0, n)
-        print("Participant {} steals one of the {} from participant {}!".format(e, item, bus[i]))
-        bus[i] = e
+        print("Participant {} steals one of the {} from participant {}!".format(names[j], item, names[bus[i]]))
+        bus[i] = j
     else:
         print("Nothing happened.")
+    j = j+1
 
+print()
+print("Winners are: ", end = '')
+for i in range(n - 1):
+    print(names[bus[i]], end = ', ')
+if n > 1:
+    print('and {}!'.format(names[bus[n-1]]))
+else:
+    print("{}!".format(names[bus[n-1]]))

--- a/busraffle.py
+++ b/busraffle.py
@@ -1,87 +1,151 @@
 from secrets import SystemRandom
 
-rng = SystemRandom()
 
-item = input("What are you giving away? ")
-n = int(input("How many {} are you giving away? ".format(item)))
-temp = input("Do you want to enter names? (y/N) ")
-print()
-useNames = (temp == "yes" or temp == "y" or temp == "Yes" or temp == "Y")
-
-names = {}
-
-if useNames:
-    for i in range(n):
-        names[i] = input("Participant: ")
-        print("You get one of the {}! For now.".format(item))
-    print()
-else:
-    print("To start, participants 0 through {} get one of the {} (for now...)".format(n - 1, item))
-    for i in range(n):
-        names[i] = str(i)
+def main():
+    # Initialize random number generator.
+    rng = SystemRandom()
+    
+    # Query user on raffle information
+    item = input("What are you giving away? ")
+    n = int(input("How many {} are you giving away? ".format(item)))
+    useNames = yes_no_check(input("Do you want to enter names? (y/N) "))
     print()
 
-bus =  list(range(n))
+    # Initialize names dictionary. Indexed at population number.
+    # Population number is independent from participant number.
+    names = {}
 
-print("List anyone who was gone, end with a blank line...")
-s = n
-while True:
+    # Using names requires entering names of each participant.
+    if useNames:
+        for i in range(n):
+            names[i] = input("Participant: ")
+            print("You get one of the {}! For now.".format(item))
+        print()
+    else:
+        print(
+            "To start, participants 0 through {} get one of the {} (for now...)".format(
+                n - 1, item))
+        # Sets name of each person into dictionary.
+        for i in range(n):
+            names[i] = str(i)
+        print()
+
+    # Define bus with first n people.
+    bus =  list(range(n))
+
+    print("List anyone who was gone, end with a blank line...")
+
+    # Participant number defined independently of population number.
+    participant_number = n
     line = input()
-    if line == '':
-        break
-    index = -1
-    for i, name in names.items():
-        if line == name:
-            index = i
-            break
-    if index == -1:
-        continue
-
-    if useNames:
-        names[index] = input("New Participant: ")
-    else:
-        names[index] = str(s)
-    s += 1
-    print("New Participant {} gets one of the {} (for now) then.".format(names[index], item))
-
-e = s
-j = n
-while True:
-    if useNames:
-        temp = input("Continue with participant (Y/n)? ")
-        quit = temp == 'y' or temp == 'Y' or temp == "yes" or temp == "Yes" or temp == ''
-        if not quit:
-            break
-    else:
-        temp = input("Continue with participant {} (Y/n)? ".format(e))
-        here = temp == 'y' or temp == 'Y' or temp == "yes" or temp == "Yes" or temp == ''
-        if not here:
-            temp = input("Quit entirely (y/N)? ")
-            if temp == 'y' or temp == 'Y' or temp == "yes" or temp == "Yes":
+    while line != "":
+        # Searches dictionary for name. If it appears,
+        # it breaks out of for loop and uses that index.
+        # -1 indicates not found
+        index = -1
+        for i, name in names.items():
+            if line == name:
+                index = i
                 break
-            e += 1
+
+        if index == -1:
             continue
 
-    e = e + 1
+        # Resets name entered. User may enter name or use next number 
+        if useNames:
+            names[index] = input("New Participant: ")
+        else:
+            names[index] = str(participant_number)
+        participant_number += 1
+        print(
+            "New Participant {} gets one of the {} (for now) then.".format(
+                names[index], item))
+        line = input()
+
+    # Name index is the population number entered into dictionary.
+    name_index = n
+    # User given option to quit or skip a number if not using names; updates part. number.
+    participant_number, more_participants = check_quitting(participant_number, useNames)
+    while more_participants:
+        if useNames:
+            name = input("Participant: ")
+            names[name_index] = name
+        else:
+            names[name_index] = participant_number
+
+        # Algorithm R sampling. See wikipedia. User steals from previous participants.
+        if rng.random() < (n / len(names)):
+            i = rng.randrange(0, n)
+            print(
+                "Participant {} steals one of the {} from participant {}!".format(
+                    names[name_index], item, names[bus[i]]))
+            bus[i] = name_index
+        else:
+            print("Nothing happened.")
+
+        name_index += 1
+        participant_number += 1
+        participant_number, more_participants = check_quitting(participant_number, useNames)
+
+    print()
+    print_winners(names, bus)
+
+
+def yes_no_check(input_string, default=False):
+    """Return boolean value of use input
+
+    Takes string and optional default value that returns with a blank value.
+    """
+    input_string = input_string.lower()
+    if (input_string == "y" or
+        input_string == "yes"):
+        return True
+    elif (input_string == 'n' or
+          input_string == 'no'):
+        return False
+
+    return default
+
+
+def check_quitting(participant_number, useNames):
+    """Query user whether to continue adding participants.
+
+    User may choose to skip numbers when not using names.
+    Otherwise, it will simply stop immediately.
+    """
     if useNames:
-        temp = input("Participant: ")
-        names[j] = temp
+        quit = yes_no_check(
+            input("Continue with participant {} (Y/n)? ".format(
+                participant_number)), True)
+        return participant_number, quit
     else:
-        names[j] = e
+        here = yes_no_check(
+            input("Continue with participant {} (Y/n)? ".format(
+                participant_number)), True)
+        if not here:
+            if yes_no_check(input("Quit entirely (y/N)? ")):
+                return participant_number, False
+            else:
+                # Skip number
+                participant_number += 1
+                return check_quitting(participant_number, useNames)
+        else:
+            return participant_number, True
 
-    if rng.random() < (n / len(names)):
-        i = rng.randrange(0, n)
-        print("Participant {} steals one of the {} from participant {}!".format(names[j], item, names[bus[i]]))
-        bus[i] = j
-    else:
-        print("Nothing happened.")
-    j = j+1
 
-print()
-print("Winners are: ", end = '')
-for i in range(n - 1):
-    print(names[bus[i]], end = ', ')
-if n > 1:
-    print('and {}!'.format(names[bus[n-1]]))
-else:
-    print("{}!".format(names[bus[n-1]]))
+def print_winners(names, bus):
+    """Prints winners after end of the raffle"""
+    if len(bus) == 1:
+        print("Winner is {}!".format(names[bus[0]]))
+    elif len(bus) == 2:
+        print("Winners are: {} and {}!".format(
+            names[bus[0]], names[bus[1]]))
+    elif len(bus) > 2:
+        print("Winners are: ", end='')
+        for i in bus[0:-1]:
+            print("{}, ".format(names[i]), end = '')
+        print("and {}!".format(names[bus[-1]]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The previous version required the user to preselect the number of
participants. This became annoying when someone new enters the room.
Now you specify the stopping point for the algorithm at each stage.

 * Query at beginning of use for names. Optional use.
 * Keep the structure of the program as close as possible to the original, so
   the program uses a few if statements with useNames as a conditional.
 * Use a dictionary to define a number to a name.
    * This also applies to using numbers, for less bias, since the number of
      people in the index increased.
 * Create better checking for y/n along with default blank option capitalized
 * Lists winners at end of game.